### PR TITLE
観戦ボタンのバグ修正

### DIFF
--- a/main.py
+++ b/main.py
@@ -47,11 +47,12 @@ class SampleView(discord.ui.View): # UIキットを利用するためにdiscord.
         
     @discord.ui.button(label="観戦モード ON", style=discord.ButtonStyle.success)
     async def observe_on(self, interaction: discord.Interaction, button: discord.ui.Button):
-        if ' //' in interaction.user.nick:
+        user_nick = interaction.user.nick or interaction.user.display_name
+        if ' //' in user_nick:
             await interaction.response.send_message(f"{interaction.user.mention} すでに観戦中です！", ephemeral=True)
         else:
             await interaction.response.send_message(f"{interaction.user.mention} 観戦モードにしました！", ephemeral=True)
-            await interaction.user.edit(nick=interaction.user.nick + " //観戦中")
+            await interaction.user.edit(nick=user_nick + " //観戦中")
 
     @discord.ui.button(label="観戦モード OFF", style=discord.ButtonStyle.danger)
     async def observe_off(self, interaction: discord.Interaction, button: discord.ui.Button):

--- a/main.py
+++ b/main.py
@@ -50,20 +50,25 @@ class SampleView(discord.ui.View): # UIキットを利用するためにdiscord.
         user_nick = interaction.user.nick or interaction.user.display_name
         if ' //' in user_nick:
             await interaction.response.send_message(f"{interaction.user.mention} すでに観戦中です！", ephemeral=True)
-        elif discord.Forbidden:
-            await interaction.response.send_message("ごめんね。僕たちが持つ権限が不足しています。自分で名前変えてね！", ephemeral=True)
         else:
-            await interaction.response.send_message(f"{interaction.user.mention} 観戦モードにしました！", ephemeral=True)
-            await interaction.user.edit(nick=user_nick + " //観戦中")
+            try:
+                await interaction.user.edit(nick=user_nick + " //観戦中")
+                await interaction.response.send_message(f"{interaction.user.mention} 観戦モードにしました！", ephemeral=True)
+                button.disabled = True
+                await interaction.message.edit(view=self)
+            except discord.Forbidden:
+                await interaction.response.send_message("ごめんね。僕たちが持つ権限が不足しています。自分で名前変えてね！", ephemeral=True)
 
     @discord.ui.button(label="観戦モード OFF", style=discord.ButtonStyle.danger)
     async def observe_off(self, interaction: discord.Interaction, button: discord.ui.Button):
         user_nick = interaction.user.nick or interaction.user.display_name
         if ' //' in user_nick:
-            await interaction.response.send_message(f"{interaction.user.mention} 観戦モードを解除しました！", ephemeral=True)
-            await interaction.user.edit(nick=user_nick.split(" //")[0])
-        elif discord.Forbidden:
-            await interaction.response.send_message("ごめんね。僕たちが持つ権限が不足しています。自分で名前変えてね！", ephemeral=True)
+            try: 
+                new_nick = user_nick.split(" //")[0]
+                await interaction.user.edit(nick=new_nick)
+                await interaction.response.send_message(f"{interaction.user.mention} 観戦モードを解除しました！", ephemeral=True)
+            except discord.Forbidden:
+                await interaction.response.send_message("ごめんね。僕たちが持つ権限が不足しています。自分で名前変えてね！", ephemeral=True)
         else:
             await interaction.response.send_message(f"{interaction.user.mention} 観戦モードではありません！", ephemeral=True)
 

--- a/main.py
+++ b/main.py
@@ -50,15 +50,20 @@ class SampleView(discord.ui.View): # UIキットを利用するためにdiscord.
         user_nick = interaction.user.nick or interaction.user.display_name
         if ' //' in user_nick:
             await interaction.response.send_message(f"{interaction.user.mention} すでに観戦中です！", ephemeral=True)
+        elif discord.Forbidden:
+            await interaction.response.send_message("ごめんね。僕たちが持つ権限が不足しています。自分で名前変えてね！", ephemeral=True)
         else:
             await interaction.response.send_message(f"{interaction.user.mention} 観戦モードにしました！", ephemeral=True)
             await interaction.user.edit(nick=user_nick + " //観戦中")
 
     @discord.ui.button(label="観戦モード OFF", style=discord.ButtonStyle.danger)
     async def observe_off(self, interaction: discord.Interaction, button: discord.ui.Button):
-        if ' //' in interaction.user.nick:
+        user_nick = interaction.user.nick or interaction.user.display_name
+        if ' //' in user_nick:
             await interaction.response.send_message(f"{interaction.user.mention} 観戦モードを解除しました！", ephemeral=True)
-            await interaction.user.edit(nick=interaction.user.nick.split(" //")[0])
+            await interaction.user.edit(nick=user_nick.split(" //")[0])
+        elif discord.Forbidden:
+            await interaction.response.send_message("ごめんね。僕たちが持つ権限が不足しています。自分で名前変えてね！", ephemeral=True)
         else:
             await interaction.response.send_message(f"{interaction.user.mention} 観戦モードではありません！", ephemeral=True)
 


### PR DESCRIPTION
#2 
- サーバでニックネームを一度でも変更していないと，Noneが帰ってくる
`user_nick = interaction.user.nick or interaction.user.display_name`
で対応．ニックネームがすでに変更されていたらinteraction.user.nickがuser_nickに代入され，一度も変更したことがない場合は，ユーザ表示名(interaction.user.display_name)がuser_nickに代入される．

- 権限高い人が名前変更すると，403が返されて処理に時間がかかる
一旦if文で条件分岐を追加することで時間がかからないように修正