### PR TITLE
ID表記固定になる問題を修正

### DIFF
--- a/main.py
+++ b/main.py
@@ -47,7 +47,7 @@ class SampleView(discord.ui.View): # 観戦ボタンのview
         
     @discord.ui.button(label="観戦モード ON", style=discord.ButtonStyle.success)
     async def observe_on(self, interaction: discord.Interaction, button: discord.ui.Button):
-        user_nick = interaction.user.nick or interaction.user.display_name
+        user_nick = interaction.user.nick or interaction.user.global_name
         if ' //' in user_nick:
             await interaction.response.send_message(f"{interaction.user.mention} すでに観戦中です！", ephemeral=True)
         else:
@@ -59,7 +59,7 @@ class SampleView(discord.ui.View): # 観戦ボタンのview
 
     @discord.ui.button(label="観戦モード OFF", style=discord.ButtonStyle.danger)
     async def observe_off(self, interaction: discord.Interaction, button: discord.ui.Button):
-        user_nick = interaction.user.nick or interaction.user.display_name
+        user_nick = interaction.user.nick or interaction.user.global_name
         if ' //' in user_nick:
             try: 
                 new_nick = user_nick.split(" //")[0]
@@ -75,7 +75,7 @@ async def observer_button(interaction: Interaction):
     view = SampleView(timeout=None)
     await interaction.response.send_message(content="観戦モード設定", view=view)
 
-TOKEN = os.getenv("DISCORD_TOKEN")
+TOKEN = os.getenv("TOKEN")
 # Web サーバの立ち上げ
 keep_alive()
 client.run(TOKEN)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-discord.py==2.1.1
+discord.py==2.3.2
 Flask==2.3.3
 discord-py-interactions==5.12.1


### PR DESCRIPTION
問題点

> 観戦を付けたときに名前がID表記固定にされます
> 観戦を外した時も名前が固定されたままなのでIDとディスコの名前が一致してない人は毎度サーバープロフィールから変更をする必要があります

変更点
- 2.3から追加されたAttributeのglobal_nameを採用
- 上記の変更に伴い、requirements.txtを合わせる。